### PR TITLE
Fix alignment and offsets to be a power of two

### DIFF
--- a/derive-storable-th.cabal
+++ b/derive-storable-th.cabal
@@ -19,7 +19,8 @@ extra-source-files:  CHANGELOG.md
 
 library
   exposed-modules:     Foreign.Storable.TH
-  other-modules:       Foreign.Storable.Internal
+                       Foreign.Storable.TH.Internal
+  -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.13 && <5
                      , template-haskell

--- a/derive-storable-th.cabal
+++ b/derive-storable-th.cabal
@@ -19,7 +19,7 @@ extra-source-files:  CHANGELOG.md
 
 library
   exposed-modules:     Foreign.Storable.TH
-  -- other-modules:
+  other-modules:       Foreign.Storable.Internal
   -- other-extensions:
   build-depends:       base >=4.13 && <5
                      , template-haskell

--- a/src/Foreign/Storable/Internal.hs
+++ b/src/Foreign/Storable/Internal.hs
@@ -1,6 +1,7 @@
-module Foreign.Storable.Internal (nearestPowerOfTwo) where
+module Foreign.Storable.Internal (nearestPowerOfTwo, tr) where
 
 import Data.Bits
+import Debug.Trace
 
 nearestPowerOfTwo :: Int -> Int
 nearestPowerOfTwo v = v6 + 1
@@ -11,3 +12,6 @@ nearestPowerOfTwo v = v6 + 1
   v3 = v2 .|. v2 `shiftR` 2
   v2 = v1 .|. v1 `shiftR` 1
   v1 = v - 1
+
+tr :: Show a => a -> a
+tr a = trace (show a) a

--- a/src/Foreign/Storable/Internal.hs
+++ b/src/Foreign/Storable/Internal.hs
@@ -1,4 +1,4 @@
-module Foreign.Storable.Internal (nearestPowerOfTwo, tr) where
+module Foreign.Storable.Internal (nearestPowerOfTwo, roundUp, tr) where
 
 import Data.Bits
 import Debug.Trace
@@ -13,5 +13,13 @@ nearestPowerOfTwo v = v6 + 1
   v2 = v1 .|. v1 `shiftR` 1
   v1 = v - 1
 
-tr :: Show a => a -> a
-tr a = trace (show a) a
+roundUp :: Int -> Int -> Int
+roundUp num 0 = num
+roundUp num mult
+  | remainder == 0 = num
+  | otherwise = num + mult - remainder
+ where
+  remainder = num `rem` mult
+
+tr :: Show a => String -> a -> a
+tr desc a = trace (desc ++ ": " ++ show a) a

--- a/src/Foreign/Storable/Internal.hs
+++ b/src/Foreign/Storable/Internal.hs
@@ -1,18 +1,12 @@
-module Foreign.Storable.Internal (nearestPowerOfTwo, roundUp, tr) where
+module Foreign.Storable.Internal (roundUp) where
 
-import Data.Bits
-import Debug.Trace
-
-nearestPowerOfTwo :: Int -> Int
-nearestPowerOfTwo v = v6 + 1
- where
-  v6 = v5 .|. v5 `shiftR` 16
-  v5 = v4 .|. v4 `shiftR` 8
-  v4 = v3 .|. v3 `shiftR` 4
-  v3 = v2 .|. v2 `shiftR` 2
-  v2 = v1 .|. v1 `shiftR` 1
-  v1 = v - 1
-
+-- | Round the first parameter to a multiple of the second parameter.
+--
+-- Examples:
+-- > roundUp 5 4
+-- 8
+-- > roundUp 14 4
+-- 16
 roundUp :: Int -> Int -> Int
 roundUp num 0 = num
 roundUp num mult
@@ -20,6 +14,3 @@ roundUp num mult
   | otherwise = num + mult - remainder
  where
   remainder = num `rem` mult
-
-tr :: Show a => String -> a -> a
-tr desc a = trace (desc ++ ": " ++ show a) a

--- a/src/Foreign/Storable/Internal.hs
+++ b/src/Foreign/Storable/Internal.hs
@@ -1,0 +1,13 @@
+module Foreign.Storable.Internal (nearestPowerOfTwo) where
+
+import Data.Bits
+
+nearestPowerOfTwo :: Int -> Int
+nearestPowerOfTwo v = v6 + 1
+ where
+  v6 = v5 .|. v5 `shiftR` 16
+  v5 = v4 .|. v4 `shiftR` 8
+  v4 = v3 .|. v3 `shiftR` 4
+  v3 = v2 .|. v2 `shiftR` 2
+  v2 = v1 .|. v1 `shiftR` 1
+  v1 = v - 1

--- a/src/Foreign/Storable/TH.hs
+++ b/src/Foreign/Storable/TH.hs
@@ -5,6 +5,7 @@ module Foreign.Storable.TH where
 import Prelude hiding (exp)
 import Data.Foldable (foldl')
 import Foreign.Storable (Storable (..))
+import Foreign.Storable.Internal (nearestPowerOfTwo)
 import Language.Haskell.TH
 
 deriveStorable :: Name -> Q [Dec]
@@ -32,7 +33,7 @@ deriveStorable name = do
     |]
  where
   cons e acc = [| $e : $acc |]
-  toSizeOf (_, t) = [| sizeOf (undefined :: $(pure t)) |]
+  toSizeOf (_, t) = [| nearestPowerOfTwo (sizeOf (undefined :: $(pure t))) |]
 
   sizeOf' :: [BangType] -> Q Exp
   sizeOf' = foldl' build [| 0 |]

--- a/src/Foreign/Storable/TH.hs
+++ b/src/Foreign/Storable/TH.hs
@@ -4,7 +4,7 @@ module Foreign.Storable.TH where
 
 import Prelude hiding (exp)
 import Foreign.Storable (Storable (..))
-import Foreign.Storable.Internal (roundUp, tr)
+import Foreign.Storable.Internal (roundUp)
 import Language.Haskell.TH
 
 deriveStorable :: Name -> Q [Dec]
@@ -26,7 +26,7 @@ deriveStorable name = do
   [d|
     instance Storable $(conT name) where
       sizeOf _ = $(sizeOf' ts)
-      alignment _ = tr "alignment" $(alignment' ts)
+      alignment _ = $(alignment' ts)
       peek = $(peek' conName ts)
       poke = $(poke' conName ts)
     |]
@@ -54,7 +54,7 @@ deriveStorable name = do
    where
     go _ expr [] = expr
     go !offset !expr (t:ts) =
-      go offset' [| $expr <*> peekByteOff $(varE ptr) (tr "offset" $offset') |] ts
+      go offset' [| $expr <*> peekByteOff $(varE ptr) $offset' |] ts
      where offset' = [| $offset + roundUp $(toSizeOf t) $(alignment' ts0) |]
 
   poke' :: Name -> [BangType] -> Q Exp

--- a/src/Foreign/Storable/TH.hs
+++ b/src/Foreign/Storable/TH.hs
@@ -4,7 +4,7 @@ module Foreign.Storable.TH where
 
 import Prelude hiding (exp)
 import Foreign.Storable (Storable (..))
-import Foreign.Storable.Internal (roundUp)
+import Foreign.Storable.TH.Internal (roundUp)
 import Language.Haskell.TH
 
 deriveStorable :: Name -> Q [Dec]

--- a/src/Foreign/Storable/TH.hs
+++ b/src/Foreign/Storable/TH.hs
@@ -3,9 +3,8 @@
 module Foreign.Storable.TH where
 
 import Prelude hiding (exp)
-import Data.Foldable (foldl')
 import Foreign.Storable (Storable (..))
-import Foreign.Storable.Internal (nearestPowerOfTwo, tr)
+import Foreign.Storable.Internal (roundUp, tr)
 import Language.Haskell.TH
 
 deriveStorable :: Name -> Q [Dec]
@@ -27,21 +26,22 @@ deriveStorable name = do
   [d|
     instance Storable $(conT name) where
       sizeOf _ = $(sizeOf' ts)
-      alignment _ = tr $(alignment' ts)
+      alignment _ = tr "alignment" $(alignment' ts)
       peek = $(peek' conName ts)
       poke = $(poke' conName ts)
     |]
  where
   cons e acc = [| $e : $acc |]
   toSizeOf (_, t) = [| sizeOf (undefined :: $(pure t)) |]
+  toAlignment (_, t) = [| alignment (undefined :: $(pure t)) |]
 
   sizeOf' :: [BangType] -> Q Exp
-  sizeOf' = foldl' build [| 0 |]
-   where build acc t = [| $(toSizeOf t) + $acc |]
+  sizeOf' ts = foldl' build [| 0 |] ts
+   where build acc t = [| roundUp $(toSizeOf t) $(alignment' ts) + $acc |]
 
   alignment' :: [BangType] -> Q Exp
   alignment' [] = [| 0 |]
-  alignment' ts = [| nearestPowerOfTwo (maximum $(foldr cons [| [] |] $ fmap toSizeOf ts)) |]
+  alignment' ts = [| maximum $(foldr cons [| [] |] $ fmap toAlignment ts) |]
 
   peek' :: Name -> [BangType] -> Q Exp
   peek' con [] = LamE [WildP] <$> [| return $(conE con) |]
@@ -54,8 +54,8 @@ deriveStorable name = do
    where
     go _ expr [] = expr
     go !offset !expr (t:ts) =
-      go offset' [| $expr <*> peekByteOff $(varE ptr) $offset' |] ts
-     where offset' = [| nearestPowerOfTwo ($offset + $(toSizeOf t)) |]
+      go offset' [| $expr <*> peekByteOff $(varE ptr) (tr "offset" $offset') |] ts
+     where offset' = [| $offset + roundUp $(toSizeOf t) $(alignment' ts0) |]
 
   poke' :: Name -> [BangType] -> Q Exp
   poke' _ []   = LamE [WildP, WildP] <$> [| return () |]
@@ -66,13 +66,16 @@ deriveStorable name = do
   poke'' :: Name -> Name -> Name -> [BangType] -> Q Exp
   poke'' ptr t con ts0 = do
     names <- traverse (\_ -> newName "temp") ts0
-    let initData =
-          ([| 0 |], [[| pokeByteOff $(varE ptr) 0 $(varE (head names)) |]])
-        (_, exps) = foldl' build initData (zip (tail names) (init ts0))
-    doE $ [bindS (conP con (varP <$> names)) [| pure $(varE t) |]]
-       <> (noBindS <$> exps)
+    case names of
+      hd : tl -> do
+        let initData =
+              ([| 0 |], [[| pokeByteOff $(varE ptr) 0 $(varE hd) |]])
+            (_, exps) = foldl' build initData (zip tl (init ts0))
+        doE $ [bindS (conP con (varP <$> names)) [| pure $(varE t) |]]
+           <> (noBindS <$> exps)
+      _ -> error "Not enough names"
    where
     build (!offset, !l) (n, ty) = (offset', exp:l)
      where
-      offset' = [| nearestPowerOfTwo ($offset + $(toSizeOf ty)) |]
+      offset' = [| $offset + roundUp $(toSizeOf ty) $(alignment' ts0) |]
       exp = [| pokeByteOff $(varE ptr) $offset' $(varE n) |]

--- a/src/Foreign/Storable/TH.hs
+++ b/src/Foreign/Storable/TH.hs
@@ -5,7 +5,7 @@ module Foreign.Storable.TH where
 import Prelude hiding (exp)
 import Data.Foldable (foldl')
 import Foreign.Storable (Storable (..))
-import Foreign.Storable.Internal (nearestPowerOfTwo)
+import Foreign.Storable.Internal (nearestPowerOfTwo, tr)
 import Language.Haskell.TH
 
 deriveStorable :: Name -> Q [Dec]
@@ -27,7 +27,7 @@ deriveStorable name = do
   [d|
     instance Storable $(conT name) where
       sizeOf _ = $(sizeOf' ts)
-      alignment _ = $(alignment' ts)
+      alignment _ = tr $(alignment' ts)
       peek = $(peek' conName ts)
       poke = $(poke' conName ts)
     |]

--- a/src/Foreign/Storable/TH/Internal.hs
+++ b/src/Foreign/Storable/TH/Internal.hs
@@ -1,4 +1,4 @@
-module Foreign.Storable.Internal (roundUp) where
+module Foreign.Storable.TH.Internal (roundUp) where
 
 -- | Round the first parameter to a multiple of the second parameter.
 --


### PR DESCRIPTION
GHC added an assertion to require that the alignment and offsets be a power of two in [this commit](https://gitlab.haskell.org/ghc/ghc/-/commit/41230e2601703df0233860be3f7d53f3a01bdbe5). This PR modifies the alignment to be the maximum alignment of the contained types instead of the maximum size of the contained types. It then modifies the offsets and total size by rounding up each contained type's size to be a multiple of the alignment. It seems to run correctly with GHC 9.12 https://github.com/DarinM223/GLexp/pull/1.